### PR TITLE
Adjust UR driver params for kinetic-devel version

### DIFF
--- a/vulcano_bringup/config/left_arm_params.yaml
+++ b/vulcano_bringup/config/left_arm_params.yaml
@@ -5,10 +5,10 @@ hardware_control_loop:
 # Settings for ros_control hardware interface
 hardware_interface:
    joints:
-     - left_arm_shoulder_pan_joint
-     - left_arm_shoulder_lift_joint
-     - left_arm_elbow_joint
-     - left_arm_wrist_1_joint
-     - left_arm_wrist_2_joint
-     - left_arm_wrist_3_joint
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint
 

--- a/vulcano_bringup/config/right_arm_params.yaml
+++ b/vulcano_bringup/config/right_arm_params.yaml
@@ -5,10 +5,10 @@ hardware_control_loop:
 # Settings for ros_control hardware interface
 hardware_interface:
    joints:
-     - right_arm_shoulder_pan_joint
-     - right_arm_shoulder_lift_joint
-     - right_arm_elbow_joint
-     - right_arm_wrist_1_joint
-     - right_arm_wrist_2_joint
-     - right_arm_wrist_3_joint
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint
 


### PR DESCRIPTION
The refactor of the `ur_modern_driver` has a slightly different way of interpreting its configuration.

This PR adjusts the configuration to adapt to that.
